### PR TITLE
feat: show ProcessMonitor loading errors

### DIFF
--- a/package/contents/ui/Cava.qml
+++ b/package/contents/ui/Cava.qml
@@ -26,10 +26,12 @@ Item {
     property bool idle
     property bool idleCheck
     property int idleTimer
-    property bool hasError: error !== ""
-    property string error
-    property bool usingFallback: process.usingFallback
-    property bool running: process.running
+    readonly property bool hasError: error !== ""
+    readonly property string error: process.stderr
+    readonly property list<string> loadingErrors: process.loadingErrors
+    readonly property bool loadingFailed: process.loadingFailed
+    readonly property bool usingFallback: process.usingFallback
+    readonly property bool running: process.running
     readonly property string cavaCommand: process.command
     readonly property string cavaConfig: {
         let config = `[general]
@@ -105,7 +107,7 @@ EOF
                 idleTimer.restart();
             }
         }
-        onStderrChanged: root.error = process.stderr
+        onLoadingErrorsChanged: root.error = process.loadingErrors.join("\n")
     }
 
     Timer {

--- a/package/contents/ui/CompactRepresentation.qml
+++ b/package/contents/ui/CompactRepresentation.qml
@@ -86,7 +86,7 @@ Item {
         waveFillColorsCfg: root.waveFillColorsCfg
         values: cava.values
         debugMode: Plasmoid.configuration.debugMode
-        visible: !cava.hasError && !cava.idle
+        visible: !cava.hasError && !cava.idle && !cava.loadingFailed
     }
     Kirigami.Icon {
         anchors.centerIn: parent
@@ -96,7 +96,7 @@ Item {
         active: mouseArea.containsMouse
         isMask: true
         color: Kirigami.Theme.negativeTextColor
-        visible: cava.hasError
+        visible: cava.hasError || cava.loadingFailed
     }
 
     MouseArea {

--- a/package/contents/ui/FullRepresentation.qml
+++ b/package/contents/ui/FullRepresentation.qml
@@ -53,6 +53,9 @@ ColumnLayout {
                     if (cava.error) {
                         msg += `Error: ${cava.error}\n`;
                     }
+                    if (!cava.running && cava.loadingFailed) {
+                        msg += `Error: ${cava.loadingErrors.join('\n')}\n`;
+                    }
                     if (cava.running) {
                         msg += `CAVA is running\n`;
                     } else {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -38,7 +38,7 @@ PlasmoidItem {
         if (Plasmoid.status === PlasmaCore.Types.RequiresAttentionStatus) {
             return;
         }
-        Plasmoid.status = (hideWhenIdle && cava.idle || !cava.running) && !Plasmoid.expanded && !editMode && !cava.hasError ? PlasmaCore.Types.HiddenStatus : PlasmaCore.Types.ActiveStatus;
+        Plasmoid.status = hideWhenIdle && (cava.idle || !cava.running) && !Plasmoid.expanded && !editMode && !cava.hasError ? PlasmaCore.Types.HiddenStatus : PlasmaCore.Types.ActiveStatus;
     }
     onExpandedChanged: {
         Utils.delay(1000, updateStatus, main);


### PR DESCRIPTION
Normally missing qml modules like `QtWebSockets` are caught during widget initialization, but I am dynamically loading components depending on whether the optional C++ plugin is installed or not, and this way just throws a warning when the widget is added to a panel or when plasma starts.

Now these errors are shown on the widget.

refs: https://github.com/luisbocanegra/kurve/issues/29